### PR TITLE
Fix for https://github.com/gfx/p5-Mouse/issues/88

### DIFF
--- a/lib/Mouse/Meta/Method/Constructor.pm
+++ b/lib/Mouse/Meta/Method/Constructor.pm
@@ -90,9 +90,9 @@ sub _generate_initialize_object {
 
         # build cde for an attribute
         if (defined $init_arg) {
-            my $value = "\$args->{q{$init_arg}}";
+            my $value = "\$is_applying_role ? \$args->{q{$key}} : \$args->{q{$init_arg}}";
 
-            $code .= "if (exists $value) {\n";
+            $code .= "if (exists \$args->{q{$init_arg}} or (\$is_applying_role and exists \$args->{q{$key}})) {\n";
 
             if($need_coercion){
                 $value = "$constraint_var->coerce($value)";
@@ -142,7 +142,7 @@ sub _generate_initialize_object {
         }
         elsif ($attr->is_required) {
             $code .= "\$meta->throw_error('Attribute ($key) is required')";
-            $code .= "    unless \$is_cloning;\n";
+            $code .= "    if (not \$is_cloning or \$is_applying_role);\n";
         }
 
         $code .= "}\n" if defined $init_arg;
@@ -173,7 +173,7 @@ sub _generate_initialize_object {
 #line 1 "%s"
     package %s;
     sub {
-        my($meta, $instance, $args, $is_cloning) = @_;
+        my($meta, $instance, $args, $is_cloning, $is_applying_role) = @_;
         %s;
         return $instance;
     }

--- a/lib/Mouse/Meta/Role/Application.pm
+++ b/lib/Mouse/Meta/Role/Application.pm
@@ -81,7 +81,7 @@ sub apply {
     if(defined $instance){ # Application::ToInstance
         # rebless instance
         bless $instance, $consumer->name;
-        $consumer->_initialize_object($instance, $instance, 1);
+        $consumer->_initialize_object($instance, $instance, 1, 1);
     }
 
     return;

--- a/lib/Mouse/PurePerl.pm
+++ b/lib/Mouse/PurePerl.pm
@@ -314,12 +314,12 @@ sub clone_object {
         || $class->throw_error("You must pass an instance of the metaclass (" . $class->name . "), not ($object)");
 
     my $cloned = bless { %$object }, ref $object;
-    $class->_initialize_object($cloned, $args, 1);
+    $class->_initialize_object($cloned, $args, 1, 0);
     return $cloned;
 }
 
 sub _initialize_object{
-    my($self, $object, $args, $is_cloning) = @_;
+    my($self, $object, $args, $is_cloning, $is_applying_role) = @_;
     # The initializer, which is used everywhere, must be clear
     # when an attribute is added. See Mouse::Meta::Class::add_attribute.
     my $initializer = $self->{_mouse_cache}{_initialize_object} ||=

--- a/t/900_mouse_bugs/021_issue88.t
+++ b/t/900_mouse_bugs/021_issue88.t
@@ -1,0 +1,53 @@
+#!perl
+use strict;
+use Test::More tests => 4;
+use Test::Exception;
+
+{
+    package Role;
+    use Mouse::Role;
+    has 'name' =>
+        (isa => 'Str', is => 'ro', required => 1);
+
+}
+
+{
+    package RoleInitArg;
+    use Mouse::Role;
+    has 'name' =>
+        (isa => 'Str', init_arg => 'Name', is => 'ro', required => 1);
+
+}
+
+{
+    package User;
+    use Mouse;
+    has 'name' =>
+        (isa => 'Str', is => 'ro');
+
+    sub BUILD
+    {
+        my $self = shift;
+        Mouse::Util::apply_all_roles($self, 'Role')
+    }
+}
+
+{
+    package UserInitArg;
+    use Mouse;
+    has 'name' =>
+        (isa => 'Str', init_arg => 'Name', is => 'ro');
+
+    sub BUILD
+    {
+        my $self = shift;
+        Mouse::Util::apply_all_roles($self, 'RoleInitArg')
+    }
+}
+
+package main;
+
+lives_ok { User->new(name => 'Tim') }, 'lives with plain attribute';
+lives_ok { UserInitArg->new(Name => 'Tim') }, 'lives with init_arg';
+dies_ok  { User->new() }, 'dies without plain attribute';
+dies_ok  { UserInitArg->new() }, 'dies without init_arg';


### PR DESCRIPTION
The changes:
Making sure that applying a role at runtime to an instance properly checks for the existence of the role's required attributes in that instance.

Hi there,
I'm long time user of the module (thanks guys), but never yet contributed.
This is one possible solution to the problem reported in the issue.
I obviously don't know any history behind the 'is_cloning' and not really sure if this issue warrants this change.
But if the issue important, here's the change.
I made sure that all tests pass and added a new test for the fix.
