### PR TITLE
support method modifiers for overrided accessor

### DIFF
--- a/t/020_attributes/037_overrided_accessor_modifier.t
+++ b/t/020_attributes/037_overrided_accessor_modifier.t
@@ -1,0 +1,219 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+{
+    package Foo;
+
+    use Mouse;
+
+    has 'foo' => (
+        is        => 'ro',
+        writer    => 'set_foo',
+        predicate => 'has_foo',
+    );
+
+    has 'set_foo_arounded' => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 0,
+    );
+
+    has 'has_foo_arounded' => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 0,
+    );
+
+    around 'has_foo' => sub {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->has_foo_arounded($self->has_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'set_foo' => sub {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->set_foo_arounded($self->set_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+}
+
+{
+    package MyFoo;
+
+    use Mouse;
+
+    sub push { return; };
+}
+
+{
+    package Bar;
+
+    use Mouse;
+
+    extends 'Foo';
+
+    has '+foo' => (
+        lazy => 0,
+    );
+
+    has 'bar' => (
+        is      => 'ro',
+        isa     => 'MyFoo',
+        reader  => 'get_bar',
+        default => sub { MyFoo->new(); },
+        handles => [qw/push/],
+    );
+
+    has 'get_bar_arounded' => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 0,
+    );
+
+    has 'bar_handle_arounded' => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 0,
+    );
+
+    around 'has_foo' => sub {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->has_foo_arounded($self->has_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'set_foo' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->set_foo_arounded($self->set_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'get_bar' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->get_bar_arounded($self->get_bar_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'push' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->bar_handle_arounded($self->bar_handle_arounded + 1);
+
+        $self->$orig(@_);
+    };
+}
+
+{
+    package Baz;
+
+    use Mouse;
+
+    extends 'Bar';
+
+    has '+bar' => (
+        lazy => 0,
+    );
+
+    around 'has_foo' => sub {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->has_foo_arounded($self->has_foo_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'get_bar' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->get_bar_arounded($self->get_bar_arounded + 1);
+
+        $self->$orig(@_);
+    };
+
+    around 'push' => sub
+    {
+        my $orig = shift;
+        my $self = shift;
+
+        $self->bar_handle_arounded($self->bar_handle_arounded + 1);
+
+        $self->$orig(@_);
+    };
+}
+
+{
+    my $foo = Foo->new;
+
+    isa_ok($foo, 'Foo');
+
+    $foo->has_foo();
+    $foo->set_foo(1);
+
+    is($foo->has_foo_arounded, 1, '... got hte correct value');
+    is($foo->set_foo_arounded, 1, '... got hte correct value');
+
+    my $bar = Bar->new;
+
+    isa_ok($bar, 'Bar');
+
+    $bar->has_foo();
+    is($bar->has_foo_arounded, 2, '... got hte correct value');
+
+    $bar->set_foo(1);
+    is($bar->set_foo_arounded, 2, '... got hte correct value');
+
+    $bar->get_bar();
+    is($bar->get_bar_arounded, 1, '... got hte correct value');
+
+    $bar->push(1);
+    # method delegation calls reader internally
+    # Mouse/Meta/Method/Delegation.pm:26-51
+    is($bar->get_bar_arounded, 2, '... got hte correct value');
+    is($bar->bar_handle_arounded, 1, '... got hte correct value');
+
+    my $baz = Baz->new;
+
+    isa_ok($baz, 'Baz');
+
+    $baz->has_foo();
+    is($baz->has_foo_arounded, 3, '... got hte correct value');
+
+    $baz->set_foo(1);
+    is($baz->set_foo_arounded, 2, '... got hte correct value');
+
+    $baz->get_bar();
+    is($baz->get_bar_arounded, 2, '... got hte correct value');
+
+    $baz->push(1);
+    is($baz->get_bar_arounded, 4, '... got hte correct value');
+    is($baz->bar_handle_arounded, 2, '... got hte correct value');
+}
+
+done_testing;


### PR DESCRIPTION
method modifiers for overrided attribute's accessors(reader/writer/accessor) are not executed when I try to use method modifiers in child class for that.

```perl
#!/usr/bin/env perl 

{
    package My;

    use Mouse;

    has 'name' =>
    (
        is      => 'ro',
        isa     => 'Str',
        default => 'noname',
        writer  => 'set_name',
    );

    around 'set_name' => sub
    {
        my $orig = shift;
        my $self = shift;

        print __PACKAGE__ . "::set_name\n";

        $self->$orig(@_);
    };
}

{
    package My::Child;

    use Mouse;

    extends 'My';

    has '+name' =>
    (
        coerce => 1,
    );

    around 'set_name' => sub
    {
        my $orig = shift;
        my $self = shift;

        print __PACKAGE__ . "::set_name\n";

        $self->$orig(@_);
    };
}

my $mychild = My::Child->new();

printf "Name: %s\n", $mychild->set_name('potatogim');
```

```
# before
> perl test.pl
My::Child::set_name
Name: potatogim

# after
> perl test.pl
My::Child::set_name
My::set_name
Name: potatogim
```

Signed-off-by: Ji-Hyeon Gim <potatogim@gluesys.com>