### PR TITLE
requires MouseX::Foreign optionally

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -26,7 +26,6 @@ on 'test' => sub {
     requires 'Test::Output';
     requires 'Test::Requires';
     requires 'Try::Tiny';
-    requires 'MouseX::Foreign';
 };
 
 on 'develop' => sub {

--- a/t/900_mouse_bugs/021_issue100_sevg.t
+++ b/t/900_mouse_bugs/021_issue100_sevg.t
@@ -2,6 +2,10 @@ use strict;
 use warnings;
 
 use Test::More;
+BEGIN {
+    eval { require MouseX::Foreign };
+    plan skip_all => "Test requires module 'MouseX::Foreign' but it's not found" if $@;
+}
 
 {
     package SuperClass;


### PR DESCRIPTION
https://github.com/xslate/p5-Mouse/pull/101#issuecomment-524869042

Note that we cannot use Test::Requires here,
because Test::Requires does "use MouseX::Foreign" (we just want to do "require MouseX::Foreign").