### PR TITLE
Fix an edge case of Int TypeConstraint would wrongly consider a non-Int scalar Int.

### DIFF
--- a/t/101_issues/Int.t
+++ b/t/101_issues/Int.t
@@ -1,0 +1,17 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use Mouse::Util::TypeConstraints;
+
+my $Int    = find_type_constraint 'Int';
+
+my $num = 3.14;
+
+ok !$Int->check($num), "\$num (== 3.14) is not Int";
+
+{ no warnings; int($num) };
+
+ok !$Int->check($num), "\$num (== 3.14) is still not Int";
+
+done_testing;

--- a/t/101_issues/Int.t
+++ b/t/101_issues/Int.t
@@ -2,16 +2,37 @@
 use strict;
 use warnings;
 use Test::More;
+use Devel::Peek qw<Dump>;
 use Mouse::Util::TypeConstraints;
 
 my $Int    = find_type_constraint 'Int';
 
-my $num = 3.14;
+subtest "Non-Int from numerical literal: my \$num = 3.14", sub {
+    my $num = 3.14;
+    ok !$Int->check($num), "\$num is not Int";
+    { no warnings; int($num) };
+    ok !$Int->check($num), "\$num is still not Int";
+};
 
-ok !$Int->check($num), "\$num (== 3.14) is not Int";
+subtest "Non-Int from string literal: my \$num = \"3.14\"", sub {
+    my $num = "3.14";
+    ok !$Int->check($num), "\$num is not Int";
+    { no warnings; int($num) };
+    ok !$Int->check($num), "\$num is still not Int";
+};
 
-{ no warnings; int($num) };
+subtest "Int from string literal: my \$num = \"3\"", sub {
+    my $num = "3";
+    ok $Int->check($num), "\$num is Int";
+    { no warnings; int($num) };
+    ok $Int->check($num), "\$num is still Int";
+};
 
-ok !$Int->check($num), "\$num (== 3.14) is still not Int";
+subtest "Int from integer literal: my \$num = 3", sub {
+    my $num = 3;
+    ok $Int->check($num), "\$num is Int";
+    { no warnings; int($num) };
+    ok $Int->check($num), "\$num is still Int";
+};
 
 done_testing;

--- a/xs-src/MouseTypeConstraints.xs
+++ b/xs-src/MouseTypeConstraints.xs
@@ -172,11 +172,11 @@ mouse_tc_Int(pTHX_ SV* const data PERL_UNUSED_DECL, SV* const sv) {
         int const num_type = grok_number(SvPVX(sv), SvCUR(sv), NULL);
         return num_type && !(num_type & IS_NUMBER_NOT_INT);
     }
-    else if(SvIOKp(sv)){
-        return TRUE;
-    }
     else if(SvNOKp(sv)) {
         return S_nv_is_integer(aTHX_ SvNVX(sv));
+    }
+    else if(SvIOKp(sv)){
+        return TRUE;
     }
     return FALSE;
 }


### PR DESCRIPTION
This PR is basically a counterpart of [the issue #8 in Type::Tiny::XS repo][1] to Mouse::XS.

The newly added test file includes the fail test cases provided by @Ovid, and I expend it to include some other scenarios too.

[1]: https://github.com/tobyink/p5-type-tiny-xs/issues/8
