### PR TITLE
Add Basic GitHub CI workflow

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -1,0 +1,150 @@
+name: testsuite
+
+on:
+  push:
+    branches:
+      - "*"
+    tags-ignore:
+      - "*"
+  pull_request:
+
+jobs:
+  # first and fast job before trying any other jobs
+
+  ubuntu:
+    env:
+      PERL_USE_UNSAFE_INC: 0
+      AUTHOR_TESTING: 1
+      AUTOMATED_TESTING: 1
+      # t/800_with_external/002-externals.t is currently failing
+      RELEASE_TESTING: 0
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: perl -V
+        run: perl -V
+      - name: install dependencies
+        uses: perl-actions/install-with-cpm@stable
+        with:
+          cpanfile: cpanfile
+          args: "--no-test --with-configure --with-develop --with-suggests"
+      - name: Build.PL
+        run: perl Build.PL
+      - run: ./Build
+      - run: ./Build test
+
+  linux:
+    name: "linux ${{ matrix.perl-version }}"
+    needs: [ubuntu]
+    env:
+      PERL_USE_UNSAFE_INC: 0
+      AUTHOR_TESTING: 1
+      AUTOMATED_TESTING: 1
+      RELEASE_TESTING: 0
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          [
+            "5.32",
+            "5.30",
+            "5.28",
+            "5.26",
+            "5.24",
+            "5.22",
+            "5.20",
+            "5.18",
+            "5.16",
+            "5.14",
+            "5.12",
+            "5.10",
+          ]
+
+    # Test-DependentModules-0.27
+    #  Configuring MetaCPAN-Client-2.026000 ... Perl v5.10.0 required--this is only v5.8.9
+    #"5.8",
+    container:
+      image: perl:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: perl -V
+        run: perl -V
+      - name: install dependencies
+        uses: perl-actions/install-with-cpanm@stable
+        with:
+          sudo: false
+          cpanfile: "cpanfile"
+          args: "-n --with-configure --with-develop --with-suggests"
+      - name: Build.PL
+        run: perl Build.PL
+      - run: ./Build
+      - run: ./Build test
+
+  macOS:
+    needs: [ubuntu]
+    env:
+      PERL_USE_UNSAFE_INC: 0
+      AUTHOR_TESTING: 1
+      AUTOMATED_TESTING: 1
+      RELEASE_TESTING: 0
+
+    runs-on: macOS-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version: [latest]
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: perl -V
+        run: perl -V
+      - name: install dependencies
+        uses: perl-actions/install-with-cpm@stable
+        with:
+          cpanfile: "cpanfile"
+          args: "--no-test --with-configure --with-develop --with-suggests"
+      - name: Build.PL
+        run: perl Build.PL
+      - run: ./Build
+      - run: ./Build test
+
+  windows:
+    needs: [ubuntu]
+    env:
+      PERL_USE_UNSAFE_INC: 0
+      AUTHOR_TESTING: 0
+      AUTOMATED_TESTING: 1
+      RELEASE_TESTING: 0
+
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version: [latest]
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set up Perl
+        run: |
+          choco install strawberryperl
+          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
+      - name: perl -V
+        run: perl -V
+      - name: install dependencies
+        uses: perl-actions/install-with-cpanm@stable
+        with:
+          sudo: false
+          cpanfile: cpanfile
+          args: "-n --with-configure --with-develop --with-suggests"
+      - name: Build.PL
+        run: perl Build.PL
+      - run: ./Build
+      - run: ./Build test


### PR DESCRIPTION
This commit is enabling GitHub CI workflow.

I noticed that `t/800_with_external/002-externals.t` is failing on the CI.

Also note that tests are failing on 5.8 due to `MetaCPAN-Client-2.026000`
which is a dependency coming from Test-DependentModules-0.27

```
Configuring MetaCPAN-Client-2.026000 ... Perl v5.10.0 required--this is only v5.8.9
```

We should consider advertising 5.10 as the minimal requirement version.

Example of build run:

https://github.com/atoomic/p5-Mouse/actions/runs/198524694
