### PR TITLE
Use Devel-PPPort 3.59

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Mouse
 
 {{$NEXT}}
+    - Use Devel-PPPort 3.59
 
 v2.5.10 2020-03-28T13:15:57Z
     - Do not use Fatal (#108)

--- a/META.json
+++ b/META.json
@@ -27,7 +27,7 @@
    "prereqs" : {
       "configure" : {
          "requires" : {
-            "Devel::PPPort" : "3.42",
+            "Devel::PPPort" : "3.59",
             "ExtUtils::ParseXS" : "3.22",
             "Module::Build" : "0.4005",
             "Module::Build::XSUtil" : "0.19",

--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -3,6 +3,8 @@ use strict;
 use warnings;
 use base qw(Module::Build::XSUtil);
 
+use Devel::PPPort 3.59;
+
 sub new {
     my ($class, %args) = @_;
     $class->SUPER::new(

--- a/cpanfile
+++ b/cpanfile
@@ -11,7 +11,7 @@ conflicts 'MouseX::AttributeHelpers', '< 0.06';
 conflicts 'MouseX::NativeTraits', '< 1.00';
 
 on configure => sub {
-    requires 'Devel::PPPort', '3.42';
+    requires 'Devel::PPPort', '3.59';
     requires 'ExtUtils::ParseXS', '3.22';
     requires 'Module::Build::XSUtil', '0.19';
     # prevent "Mouse::Deprecated does not define $VERSION" error in test under perl 5.8

--- a/xs-src/MouseUtil.xs
+++ b/xs-src/MouseUtil.xs
@@ -124,7 +124,7 @@ mouse_throw_error(SV* const metaobject, SV* const data /* not used */, const cha
     }
 }
 
-#if (PERL_BCDVERSION < 0x5014000)
+#if PERL_VERSION_LT(5,14,0)
 /* workaround Perl-RT #69939 */
 I32
 mouse_call_sv_safe(pTHX_ SV* const sv, I32 const flags) {
@@ -135,7 +135,7 @@ mouse_call_sv_safe(pTHX_ SV* const sv, I32 const flags) {
     SAVEGENERICSV(ERRSV); /* local $@ */
     ERRSV = newSV(0);
 
-    count = Perl_call_sv(aTHX_ sv, flags | G_EVAL);
+    count = call_sv(aTHX_ sv, flags | G_EVAL);
 
     if(sv_true(ERRSV)){
         SV* const err = sv_mortalcopy(ERRSV);

--- a/xs-src/mouse.h
+++ b/xs-src/mouse.h
@@ -1,10 +1,17 @@
 #ifndef MOUSE_H
 #define MOUSE_H
 
-#define NEED_mg_findext
+/* used by 'ppport.h' Devel-PPPort */
+#define NEED_croak_xs_usage
 #define NEED_gv_fetchpvn_flags
-#define NEED_SvRX
+#define NEED_mg_findext
 #define NEED_newSVpvn_flags
+#define NEED_newSVpvn_share
+#define NEED_SvRX
+#define NEED_warner
+#define NEED_grok_number
+#define NEED_grok_numeric_radix
+
 #define PERL_EUPXS_ALWAYS_EXPORT
 
 #include "xshelper.h"
@@ -47,7 +54,7 @@ void
 mouse_throw_error(SV* const metaobject, SV* const data /* not used */, const char* const fmt, ...)
     __attribute__format__(__printf__, 3, 4);
 
-#if (PERL_BCDVERSION < 0x5014000)
+#if PERL_VERSION_LT(5,14,0)
 /* workaround RT #69939 */
 I32
 mouse_call_sv_safe(pTHX_ SV*, I32);


### PR DESCRIPTION
Devel-PPPort 3.59 provides some compare macro which we can now use.

Also add a few recommendations from the last version of 'ppport.h'.