### PR TITLE
provide empty import on Mouse::Deprecated for imported Moose test

### DIFF
--- a/t/lib/MooseCompat.pm
+++ b/t/lib/MooseCompat.pm
@@ -17,6 +17,8 @@ $INC{'Mouse/Deprecated.pm'}    = __FILE__;
     $thing->isa($role);
 } unless UNIVERSAL->can('DOES');
 
+# ignore arguments in imported Moose test
+sub Mouse::Deprecated::import {}
 $Mouse::Deprecated::deprecated = $Mouse::Deprecated::deprecated = undef; # -w
 
 package Mouse::Util;


### PR DESCRIPTION
One of the translated tests imported from Moose includes a line

use Mouse::Deprecated -api_version => '1.07';

Our tests set up a fake Mouse::Deprecated package to ignore this. But newer versions of perl will no longer ignore the arguments passed to the undefined import method, and instead will throw an error.

Add an empty import method to entirely ignore these arguments.