### PR TITLE
Use perl-actions/perl-versions and use perl-tester

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -22,22 +22,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: perl -V
-        run: perl -V
+      - uses: actions/checkout@v4
+      - run: perl -V
       - name: install dependencies
-        uses: perl-actions/install-with-cpm@stable
+        uses: perl-actions/install-with-cpm@v1
         with:
           cpanfile: cpanfile
           args: "--no-test --with-configure --with-develop --with-suggests"
-      - name: Build.PL
-        run: perl Build.PL
+      - run: perl Build.PL
       - run: ./Build
       - run: ./Build test
 
+  perl-versions:
+    runs-on: ubuntu-latest
+    name: List Perl versions
+    outputs:
+      perl-versions: ${{ steps.action.outputs.perl-versions }}
+    steps:
+      - id: action
+        uses: perl-actions/perl-versions@v1
+        with:
+          since-perl: v5.10
+
   linux:
-    name: "linux ${{ matrix.perl-version }}"
-    needs: [ubuntu]
+    name: "Perl ${{ matrix.perl-version }}"
+    needs:
+      - ubuntu
+      - perl-versions
     env:
       PERL_USE_UNSAFE_INC: 0
       AUTHOR_TESTING: 1
@@ -49,102 +60,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        perl-version:
-          [
-            "5.32",
-            "5.30",
-            "5.28",
-            "5.26",
-            "5.24",
-            "5.22",
-            "5.20",
-            "5.18",
-            "5.16",
-            "5.14",
-            "5.12",
-            "5.10",
-          ]
+        perl-version: ${{ fromJson (needs.perl-versions.outputs.perl-versions) }}
 
-    # Test-DependentModules-0.27
-    #  Configuring MetaCPAN-Client-2.026000 ... Perl v5.10.0 required--this is only v5.8.9
-    #"5.8",
-    container:
-      image: perl:${{ matrix.perl-version }}
+    container: perldocker/perl-tester:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v2
-      - name: perl -V
-        run: perl -V
+      - uses: actions/checkout@v4
+      - run: perl -V
       - name: install dependencies
-        uses: perl-actions/install-with-cpanm@stable
+        uses: perl-actions/install-with-cpanm@v1
         with:
           sudo: false
           cpanfile: "cpanfile"
           args: "-n --with-configure --with-develop --with-suggests"
-      - name: Build.PL
-        run: perl Build.PL
-      - run: ./Build
-      - run: ./Build test
-
-  macOS:
-    needs: [ubuntu]
-    env:
-      PERL_USE_UNSAFE_INC: 0
-      AUTHOR_TESTING: 1
-      AUTOMATED_TESTING: 1
-      RELEASE_TESTING: 0
-
-    runs-on: macOS-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        perl-version: [latest]
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: perl -V
-        run: perl -V
-      - name: install dependencies
-        uses: perl-actions/install-with-cpm@stable
-        with:
-          cpanfile: "cpanfile"
-          args: "--no-test --with-configure --with-develop --with-suggests"
-      - name: Build.PL
-        run: perl Build.PL
-      - run: ./Build
-      - run: ./Build test
-
-  windows:
-    needs: [ubuntu]
-    env:
-      PERL_USE_UNSAFE_INC: 0
-      AUTHOR_TESTING: 0
-      AUTOMATED_TESTING: 1
-      RELEASE_TESTING: 0
-
-    runs-on: windows-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        perl-version: [latest]
-
-    steps:
-      - uses: actions/checkout@master
-      - name: Set up Perl
-        run: |
-          choco install strawberryperl
-          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" >> $GITHUB_PATH
-      - name: perl -V
-        run: perl -V
-      - name: install dependencies
-        uses: perl-actions/install-with-cpanm@stable
-        with:
-          sudo: false
-          cpanfile: cpanfile
-          args: "-n --with-configure --with-develop --with-suggests"
-      - name: Build.PL
-        run: perl Build.PL
+      - run: perl Build.PL
       - run: ./Build
       - run: ./Build test


### PR DESCRIPTION
Use perl-actions/perl-versions to get an up to date and dynamic list of Perl versions.

Stop running the pipelines on Windows and macOS
as these are pretty ressource expensive from GitHub