### PR TITLE
update .github/workflows/testsuite.yml

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: perl -V
         run: perl -V
       - name: install dependencies
-        uses: perl-actions/install-with-cpm@stable
+        uses: perl-actions/install-with-cpm@v1
         with:
           cpanfile: cpanfile
           args: "--no-test --with-configure --with-develop --with-suggests"
@@ -54,15 +54,14 @@ jobs:
             "5.32",
             "5.30",
             "5.28",
-            "5.26",
-            "5.24",
-            "5.22",
-            "5.20",
-            "5.18",
-            "5.16",
-            "5.14",
-            "5.12",
-            "5.10",
+            "5.26-buster",
+            "5.24-buster",
+            "5.22-buster",
+            "5.20-buster",
+            "5.18-buster",
+            "5.16-buster",
+            "5.14-buster",
+            "5.12-buster",
           ]
 
     # Test-DependentModules-0.27
@@ -72,11 +71,11 @@ jobs:
       image: perl:${{ matrix.perl-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: perl -V
         run: perl -V
       - name: install dependencies
-        uses: perl-actions/install-with-cpanm@stable
+        uses: perl-actions/install-with-cpanm@v1
         with:
           sudo: false
           cpanfile: "cpanfile"
@@ -102,11 +101,11 @@ jobs:
         perl-version: [latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: perl -V
         run: perl -V
       - name: install dependencies
-        uses: perl-actions/install-with-cpm@stable
+        uses: perl-actions/install-with-cpm@v1
         with:
           cpanfile: "cpanfile"
           args: "--no-test --with-configure --with-develop --with-suggests"
@@ -131,7 +130,7 @@ jobs:
         perl-version: [latest]
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Set up Perl
         run: |
           choco install strawberryperl
@@ -139,7 +138,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: install dependencies
-        uses: perl-actions/install-with-cpanm@stable
+        uses: perl-actions/install-with-cpanm@v1
         with:
           sudo: false
           cpanfile: cpanfile


### PR DESCRIPTION
* actions/checkout v2 -> v4
* perl-actions/install-with-cpanm/cpm stable -> v1
* use buster images for old perls https://github.com/Perl/docker-perl/issues/161
* remove perl 5.10 because some dependencies require perl 5.12