### PR TITLE
mark "builtin" as foreign

### DIFF
--- a/lib/Mouse/Meta/Module.pm
+++ b/lib/Mouse/Meta/Module.pm
@@ -78,6 +78,7 @@ sub get_attribute_list{ keys   %{$_[0]->{attributes}} }
 my %foreign = map{ $_ => undef } qw(
     Mouse Mouse::Role Mouse::Util Mouse::Util::TypeConstraints
     Carp Scalar::Util List::Util
+    builtin
 );
 sub _get_method_body {
     my($self, $method_name) = @_;


### PR DESCRIPTION
On perl 5.40.0, Scalar::Util 1.64, some tests fail:

```
#   Failed test at t/001_mouse/034-apply_all_roles.t line 43.
#          got: 'bar,blessed,foo,meta,method'
#     expected: 'bar,foo,meta,method'
# Looks like you failed 1 test of 9.
```

This is because, on perl 5.40.0, Scalar::Util 1.64,
the "blessed" function actually comes from "builtin" package.
https://metacpan.org/release/PEVANS/Scalar-List-Utils-1.64/source/lib/Scalar/Util.pm#L26-37

So we should mark "builtin" as foreign.