### PR TITLE
Fix the trigger documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ this class. Options:
 
 - `trigger => CodeRef`
 
-    Any time the attribute's value is set (either through the accessor or the constructor), the trigger is called on it. The trigger receives as arguments the instance, and the new value.
+    Any time the attribute's value is set (either through the accessor or the constructor), the trigger is called on it. The trigger receives as arguments the instance, the new value, and optionally the old value if it differs from the new value.
 
 - `builder => Str`
 

--- a/lib/Mouse.pm
+++ b/lib/Mouse.pm
@@ -352,7 +352,7 @@ Use of this feature requires L<Scalar::Util>!
 
 =item C<< trigger => CodeRef >>
 
-Any time the attribute's value is set (either through the accessor or the constructor), the trigger is called on it. The trigger receives as arguments the instance, and the new value.
+Any time the attribute's value is set (either through the accessor or the constructor), the trigger is called on it. The trigger receives as arguments the instance, the new value, and optionally the old value if it differs from the new value.
 
 =item C<< builder => Str >>
 


### PR DESCRIPTION
Document the (optional) third argument introduced in #6 if the new value differs from the old value.

This was causing a perplexing error in trigger subs with a signature expecting only the invocant and the new value:

> Too many arguments for method (anon) (expected 2, got 3) at rw-accessor for &lt;field&gt; (Mouse/Meta/Method/Accessor.pm) line 8